### PR TITLE
fix: create missing index for key field in mongoDb

### DIFF
--- a/lib/mongodb-backend.js
+++ b/lib/mongodb-backend.js
@@ -118,6 +118,7 @@ MongoDBBackend.prototype = {
 
         if (key == "key") throw new Error("Key name 'key' is not allowed.");
         key = encodeText(key);
+        var collectionIndex = this.useSingle ? { _bucketname: 1, key: 1 } : { key: 1 };
         var updateParams = this.useSingle ? { _bucketname: bucket, key: key } : { key: key };
         var collName = this.useSingle ? aclCollectionName : bucket;
         transaction.push((cb) => {
@@ -142,7 +143,7 @@ MongoDBBackend.prototype = {
         transaction.push((cb) => {
             this.db.collection(this.prefix + this.removeUnsupportedChar(collName), (err, collection) => {
                 // Create index
-                collection.createIndex({ _bucketname: 1, key: 1 }, (err) => {
+                collection.createIndex(collectionIndex, (err) => {
                     if (err instanceof Error) {
                         return cb(err);
                     } else {


### PR DESCRIPTION
As discussed https://github.com/flash-oss/node_acl/issues/4 , this pr is for adding the missing index when using `useSingle=false`. Didn't  find any tests that need to be updated. 