### PR TITLE
Fix Markdown syntax and fine tune documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Using npm:
 npm install acl2
 ```
 
-Optionally: 
+Optionally:
 
 ```shell script
 npm install mongodb
@@ -116,7 +116,7 @@ acl = new ACL(new ACL.memoryBackend());
 acl = new ACL(new ACL.mongodbBackend({ client: mongoClient }));
 ```
 
-See below for full list of backend constructor arguments. 
+See below for full list of backend constructor arguments.
 
 All the following functions return a promise or optionally take a callback with
 an err parameter as last parameter. We omit them in the examples for simplicity.
@@ -545,7 +545,7 @@ Creates a MongoDB backend instance.
 **Arguments**
 
 ```javascript
-    client    {Object} MongoClient instance. If missing, the `db` will be used. 
+    client    {Object} MongoClient instance. If missing, the `db` will be used.
     db        {Object} Database instance. If missing, the `client` will be used.
     prefix    {String} Optional collection prefix. Default is "acl_".
     useSingle {Boolean} Create one collection for all resources (defaults to false)
@@ -566,7 +566,7 @@ Creates a Redis backend instance.
 **Arguments**
 
 ```javascript
-    client    {Object} Redis client instance. 
+    client    {Object} Redis client instance.
     prefix    {String} Optional prefix. Default is "acl_".
 ```
 
@@ -593,4 +593,4 @@ npm run test_memory
 npm run test_redis
 npm run test_mongo
 npm run test_mongo_single
-``` 
+```

--- a/README.md
+++ b/README.md
@@ -52,8 +52,6 @@ new ACL.redisBackend({ redis, prefix = "acl_" })
 * Removed all possible warnings
 * Run CI tests using multiple MongoDB versions.
 
-### 
-
 ## Features
 
 - Users

--- a/README.md
+++ b/README.md
@@ -375,6 +375,7 @@ Removes a role from the system.
 ---
 
 <a name="removeResource" />
+
 ### removeResource( resource, function(err) )
 
 Removes a resource from the system


### PR DESCRIPTION
- Fix Markdown syntax
  - Before:
    - <img width="775" alt="截圖 2022-06-20 12 27 32" src="https://user-images.githubusercontent.com/1018482/174525559-6239a843-f750-445e-9290-8ca74037d4ab.png">
  - After:
    - <img width="775" alt="截圖 2022-06-20 12 30 16" src="https://user-images.githubusercontent.com/1018482/174525571-988884bf-b1fe-498b-a885-358611edb284.png">
- Fine tune documentation
  - Remove ending spaces in the documentation
  - Remove an unnecessary heading in the documentation