### PR TITLE
Make sure to accept empty string as prefix

### DIFF
--- a/lib/mongodb-backend.js
+++ b/lib/mongodb-backend.js
@@ -13,7 +13,7 @@ const aclCollectionName = "resources";
 function MongoDBBackend({ client, db, prefix, useSingle, useRawCollectionNames }) {
     this.client = client;
     this.db = db || client.db(client.s.options.dbName);
-    this.prefix = prefix || "acl_";
+    this.prefix = typeof prefix !== 'undefined' ? prefix : "acl_";
     this.useSingle = Boolean(useSingle);
     this.useRawCollectionNames = useRawCollectionNames === false; // requires explicit boolean false value
 }


### PR DESCRIPTION
Alternatively if support for Node v15 is required 

```javascript
this.prefix = prefix ?? "acl_";
```